### PR TITLE
fix(hashline): replace silent boundary auto-fix with terse [W_DUP] warning (closes #12)

### DIFF
--- a/prompts/replace-guidelines.md
+++ b/prompts/replace-guidelines.md
@@ -4,3 +4,5 @@
 - hash_range_inclusive replaces the ENTIRE range inclusively. Every line from the first anchor through the second anchor is deleted. Only put replacement lines in content_lines — do not include lines that already exist outside the range.
 - Preserve leading whitespace exactly. The content after │ in read output includes all leading spaces and tabs — copy them into content_lines unchanged.
 - content_lines must be a native JSON array of strings, not a JSON string.
+- **Boundary check:** scan your content_lines before submitting. If the first non-empty line matches the line before start_hash, remove it. If the last non-empty line matches the line after end_hash, remove it. Those lines survive outside your range. A [W_DUP] warning signals you missed this.
+- **Moving blocks:** to move a block atomically, use two changes in one `changes` array: (1) delete source `{ content_lines: [], hash_range_inclusive: [srcStart, srcEnd] }`, (2) insert at target by replacing the target line with itself plus the moved content `{ content_lines: [targetLine, ...movedLines], hash_range_inclusive: [targetHash, targetHash] }`. Both validated against one snapshot — no shifting anchors.

--- a/prompts/replace.md
+++ b/prompts/replace.md
@@ -27,6 +27,7 @@ Rules:
 - Preserve leading whitespace exactly as it appears after │ in read output.
 - To delete lines, use content_lines: [].
 - If content_lines matches current content, the edit is a noop (file unchanged).
+- **Verify boundaries:** before submitting, check your `content_lines`. If its first non-empty line matches the line just before `start_hash`, remove it — that line survives outside your range. If its last non-empty line matches the line just after `end_hash`, remove it — it also survives. A `[W_DUP]` warning means you missed this check.
 {{MODE_RULES}}
 On success, the response shows the change summary. {{AUTO_READ_GUIDANCE}}
 

--- a/src/hashline/apply.ts
+++ b/src/hashline/apply.ts
@@ -242,7 +242,6 @@ export function applyEdits(
 		edits,
 		lineIndex.fileLines,
 		fileHashes,
-		warnings,
 		signal,
 	);
 	if (mismatches.length) {

--- a/src/hashline/apply.ts
+++ b/src/hashline/apply.ts
@@ -1,4 +1,4 @@
-import { abortIf, visLines, lastNonEmptyIndex, firstNonEmptyIndex } from "../utils";
+import { abortIf, visLines } from "../utils";
 import { _lineHashesPure, HASH_SEP } from "./hash";
 import {
 	valEdits,
@@ -10,7 +10,6 @@ import {
 	type NEdit,
 	type HEdit,
 	type BDupWarn,
-	type AutoFix,
 } from "./resolve";
 
 type LIdx = {
@@ -212,43 +211,7 @@ function assemble(
 	return result;
 }
 
-export function fmtBoundaryWarning(params: {
-	kind: "trailing" | "leading";
-	survivingContent: string;
-	matchIndex: number;
-	resultLines: string[];
-	resultHashes: string[];
-}): string {
-	const header =
-		params.kind === "trailing"
-			? "Boundary duplication (trailing): the last replacement line duplicated the next line. This happens when `content_lines` includes a line that was already outside the replaced range. Delete the duplicate — the original line outside the range is still there."
-			: "Boundary duplication (leading): the first replacement line duplicated the previous line. This happens when `content_lines` includes a line that was already outside the replaced range. Delete the duplicate — the original line outside the range is still there.";
 
-	let pairStart = -1;
-	let bestDist = Infinity;
-	for (let i = 0; i < params.resultLines.length - 1; i++) {
-		if (
-			params.resultLines[i] === params.survivingContent &&
-			params.resultLines[i + 1] === params.survivingContent
-		) {
-			const dist = Math.abs(i - params.matchIndex);
-			if (dist < bestDist) {
-				bestDist = dist;
-				pairStart = i;
-			}
-		}
-	}
-	if (pairStart < 0) pairStart = params.matchIndex;
-
-	const winStart = Math.max(0, pairStart - 2);
-	const winEnd = Math.min(params.resultLines.length - 1, pairStart + 3);
-
-	const rows: string[] = [];
-	for (let i = winStart; i <= winEnd; i++) {
-		rows.push(`${params.resultHashes[i]}${HASH_SEP}${params.resultLines[i]}`);
-	}
-	return `${header}\n\n${rows.join("\n")}`;
-}
 
 export function applyEdits(
 	content: string,
@@ -256,13 +219,12 @@ export function applyEdits(
 	signal?: AbortSignal,
 	precomputedHashes?: string[],
 	filePath?: string,
-	): {
+): {
 	content: string;
 	firstChangedLine: number | undefined;
 	lastChangedLine: number | undefined;
 	warnings?: string[];
 	noopEdits?: NEdit[];
-	autoFixes?: AutoFix[];
 } {
 	abortIf(signal);
 	if (!edits.length)
@@ -277,7 +239,7 @@ export function applyEdits(
 	const noopEdits: NEdit[] = [];
 	const warnings: string[] = [];
 
-	const { resolved: initialResolved, mismatches, boundaryWarnings } = valEdits(
+	const { resolved, mismatches, boundaryWarnings } = valEdits(
 		edits,
 		lineIndex.fileLines,
 		fileHashes,
@@ -293,44 +255,13 @@ export function applyEdits(
 	assertNoBarePrefix(edits, lineIndex.fileLines, fileHashes);
 	warnUnicodeEsc(edits, warnings);
 
-	let resolved = initialResolved;
-	let autoFixes: AutoFix[] | undefined;
-	if (boundaryWarnings.length > 0) {
-		autoFixes = [];
-		const correctedEdits: HEdit[] = edits.map(e => ({
-			...e,
-			content_lines: [...e.content_lines],
-		}));
-		for (const bw of boundaryWarnings) {
-			const edit = correctedEdits[bw.editIndex];
-			if (!edit) continue;
-			if (bw.kind === "trailing") {
-				const idx = lastNonEmptyIndex(edit.content_lines);
-				if (idx >= 0) {
-					const removed = edit.content_lines.splice(idx, 1)[0];
-					autoFixes.push({ kind: "trailing", editIndex: bw.editIndex, removedLine: removed });
-				}
-			} else {
-				const idx = firstNonEmptyIndex(edit.content_lines);
-				if (idx >= 0) {
-					const removed = edit.content_lines.splice(idx, 1)[0];
-					autoFixes.push({ kind: "leading", editIndex: bw.editIndex, removedLine: removed });
-				}
-			}
-		}
-		const correctedResult = valEdits(
-			correctedEdits,
-			lineIndex.fileLines,
-			fileHashes,
-			warnings,
-			signal,
-		);
-		if (correctedResult.mismatches.length) {
-			throw new Error(
-				fmtMismatch(correctedResult.mismatches, lineIndex.fileLines, fileHashes, filePath),
-			);
-		}
-		resolved = correctedResult.resolved;
+
+	// Convert boundary warnings to terse [W_DUP] warnings (no silent auto-fix)
+	for (const bw of boundaryWarnings) {
+		const adj = JSON.stringify(bw.survivingLineContent);
+		const kind = bw.kind === "trailing" ? "ends with" : "starts with";
+		const location = bw.kind === "trailing" ? "next surviving" : "preceding";
+		warnings.push(`[W_DUP] content_lines ${kind} ${adj} which matches the ${location} line. If unintentional, widen your hash_range_inclusive to include it.`);
 	}
 
 	const orderedSpans = resSpans(
@@ -351,7 +282,6 @@ export function applyEdits(
 		lastChangedLine: range?.lastChangedLine,
 		...(warnings.length ? { warnings } : {}),
 		...(noopEdits.length ? { noopEdits } : {}),
-		...(autoFixes ? { autoFixes } : {}),
 	};
 }
 

--- a/src/hashline/apply.ts
+++ b/src/hashline/apply.ts
@@ -212,7 +212,6 @@ function assemble(
 }
 
 
-
 export function applyEdits(
 	content: string,
 	edits: HEdit[],

--- a/src/hashline/index.ts
+++ b/src/hashline/index.ts
@@ -25,17 +25,16 @@ export {
 	type HTEdit,
 	type NEdit,
 	type BDupWarn,
-	type AutoFix,
 	descEdit,
 	resEdits,
 	valEdits,
 	assertNoBarePrefix,
 	fmtMismatch,
 } from "./resolve";
+
 export {
 	buildIdx,
 	applyEdits,
 	fmtRegion,
 	changedRange,
-	fmtBoundaryWarning,
 } from "./apply";

--- a/src/hashline/resolve.ts
+++ b/src/hashline/resolve.ts
@@ -29,11 +29,7 @@ export interface BDupWarn {
 	editIndex: number;
 }
 
-export interface AutoFix {
-  kind: "trailing" | "leading";
-  editIndex: number;
-  removedLine: string;
-}
+
 
 
 export interface NEdit {

--- a/src/hashline/resolve.ts
+++ b/src/hashline/resolve.ts
@@ -24,9 +24,6 @@ interface HMismatch {
 export interface BDupWarn {
 	kind: "trailing" | "leading";
 	survivingLineContent: string;
-	survivingLineIndex: number;
-	replacementLineContent: string;
-	editIndex: number;
 }
 
 
@@ -240,8 +237,6 @@ function checkBoundaryDup(
 	adjacentLine: string | undefined,
 	replacementEdge: string | undefined,
 	kind: "trailing" | "leading",
-	survivingLineIndex: number,
-	editIndex: number,
 ): BDupWarn | null {
 	if (
 		adjacentLine === undefined ||
@@ -249,13 +244,10 @@ function checkBoundaryDup(
 		replacementEdge.length === 0 ||
 		replacementEdge !== adjacentLine
 	) return null;
-  return {
-    kind,
-    survivingLineContent: adjacentLine,
-    survivingLineIndex,
-    replacementLineContent: replacementEdge,
-    editIndex,
-  };
+	return {
+		kind,
+		survivingLineContent: adjacentLine,
+	};
 }
 
 
@@ -303,11 +295,11 @@ export function valEdits(
 		const endLine = endResolved.line;
 		const nextLine = fileLines[endLine];
 		const replacementLastLine = lastNonEmpty(edit.content_lines);
-		const trailing = checkBoundaryDup(nextLine, replacementLastLine, "trailing", endLine, resolved.length);
+		const trailing = checkBoundaryDup(nextLine, replacementLastLine, "trailing");
 		if (trailing) boundaryWarnings.push(trailing);
 		const prevLine = fileLines[startResolved.line - 2];
 		const replacementFirstLine = firstNonEmpty(edit.content_lines);
-		const leading = checkBoundaryDup(prevLine, replacementFirstLine, "leading", startResolved.line - 2, resolved.length);
+		const leading = checkBoundaryDup(prevLine, replacementFirstLine, "leading");
 		if (leading) boundaryWarnings.push(leading);
 		resolved.push({
 			content_lines: edit.content_lines,

--- a/src/hashline/resolve.ts
+++ b/src/hashline/resolve.ts
@@ -255,7 +255,6 @@ export function valEdits(
 	edits: HEdit[],
 	fileLines: string[],
 	fileHashes: string[],
-	warnings: string[],
 	signal: AbortSignal | undefined,
 ): { resolved: RHEdit[]; mismatches: HMismatch[]; boundaryWarnings: BDupWarn[] } {
 	assertAligned(fileLines, fileHashes, "valEdits");

--- a/test/core/hashline-apply-internals.test.ts
+++ b/test/core/hashline-apply-internals.test.ts
@@ -40,80 +40,83 @@ describe("resAnchor (via valEdits)", () => {
   });
 });
 
-describe("checkBoundaryDup (via valEdits) — auto-fix", () => {
-  it("auto-fixes trailing duplication", async () => {
+describe("checkBoundaryDup (via valEdits) — [W_DUP] warning", () => {
+  it("warns on trailing duplication (duplicate kept)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["X", "d"] },
     ]));
-    expect(result.content).toBe("a\nX\nd");
-    expect(result.autoFixes).toBeDefined();
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
+    // Duplicate kept (not auto-fixed)
+    expect(result.content).toBe("a\nX\nd\nd");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("ends with"))).toBe(true);
   });
 
-  it("auto-fixes leading duplication", async () => {
+  it("warns on leading duplication (duplicate kept)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["a", "X"] },
     ]));
-    expect(result.content).toBe("a\nX\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    // Duplicate kept (not auto-fixed)
+    expect(result.content).toBe("a\na\nX\nd");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with"))).toBe(true);
   });
 
-  it("does not auto-fix when replacement does not duplicate adjacent lines", async () => {
+  it("does not warn when replacement does not duplicate adjacent lines", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["X", "Y"] },
     ]));
-    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.warnings?.some(w => w.startsWith("[W_DUP]")) ?? false).toBe(false);
   });
 
-  it("does not auto-fix when replacement edge is empty string", async () => {
+  it("does not warn when replacement edge is empty string", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: [] },
     ]));
-    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.warnings?.some(w => w.startsWith("[W_DUP]")) ?? false).toBe(false);
   });
 
-  it("auto-fixes trailing duplication when content_lines has trailing empty lines", async () => {
+  it("warns on trailing duplication when content_lines has trailing empty lines", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["X", "d", ""] },
     ]));
-    expect(result.content).toBe("a\nX\n\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
-    expect(result.autoFixes![0]!.removedLine).toBe("d");
+    // Duplicate kept
+    expect(result.content).toBe("a\nX\nd\n\nd");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("ends with") && w.includes("d"))).toBe(true);
   });
 
-  it("auto-fixes leading duplication when content_lines has leading empty lines", async () => {
+  it("warns on leading duplication when content_lines has leading empty lines", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["", "a", "X"] },
     ]));
-    expect(result.content).toBe("a\n\nX\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
-    expect(result.autoFixes![0]!.removedLine).toBe("a");
+    // Duplicate kept
+    expect(result.content).toBe("a\n\na\nX\nd");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with") && w.includes("a"))).toBe(true);
   });
 
-  it("auto-fixes both trailing and leading in one edit", async () => {
+  it("warns on both trailing and leading duplication in one edit", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["a", "d"] },
     ]));
-    expect(result.content).toBe("a\nd");
-    expect(result.autoFixes).toHaveLength(2);
+    // Both duplicates kept
+    expect(result.content).toBe("a\na\nd\nd");
+    const dupWarnings = result.warnings?.filter(w => w.startsWith("[W_DUP]")) ?? [];
+    expect(dupWarnings).toHaveLength(2);
   });
 });
 
@@ -248,39 +251,41 @@ describe("resSpans (via applyEdits)", () => {
   });
 });
 
-describe("auto-fix via applyEdits", () => {
-  it("auto-fixes trailing duplication", async () => {
+describe("[W_DUP] warning via applyEdits", () => {
+  it("warns on trailing duplication (duplicate kept)", async () => {
     const content = "before\nold one\nold two\nafter";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["new one", "new two", "after"] },
     ]));
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
-    expect(result.autoFixes![0]!.removedLine).toBe("after");
-    expect(result.content).toBe("before\nnew one\nnew two\nafter");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("ends with") && w.includes("after"))).toBe(true);
+    // Duplicate kept
+    expect(result.content).toBe("before\nnew one\nnew two\nafter\nafter");
   });
 
-  it("auto-fixes leading duplication", async () => {
+  it("warns on leading duplication (duplicate kept)", async () => {
     const content = "before\nold one\nold two\nafter";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["before", "new one", "new two"] },
     ]));
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
-    expect(result.autoFixes![0]!.removedLine).toBe("before");
-    expect(result.content).toBe("before\nnew one\nnew two\nafter");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with") && w.includes("before"))).toBe(true);
+    // Duplicate kept
+    expect(result.content).toBe("before\nbefore\nnew one\nnew two\nafter");
   });
 
-  it("auto-fixes both leading and trailing in one edit", async () => {
+  it("warns on both leading and trailing duplication in one edit (duplicates kept)", async () => {
     const content = "ctx1\nctx2\nold1\nold2\nctx3\nctx4";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdits(content, resEdits([
       { hash_range_inclusive: [hashes[2]!, hashes[3]!], content_lines: ["ctx2", "dup", "dup", "ctx3"] },
     ]));
-    expect(result.autoFixes).toBeDefined();
-    expect(result.autoFixes).toHaveLength(2);
-    expect(result.content).toBe("ctx1\nctx2\ndup\ndup\nctx3\nctx4");
+    expect(result.warnings).toBeDefined();
+    const dupWarnings = result.warnings!.filter(w => w.startsWith("[W_DUP]"));
+    expect(dupWarnings).toHaveLength(2);
+    // Both duplicates kept
+    expect(result.content).toBe("ctx1\nctx2\nctx2\ndup\ndup\nctx3\nctx3\nctx4");
   });
 });

--- a/test/core/hashline-boundary-warning.test.ts
+++ b/test/core/hashline-boundary-warning.test.ts
@@ -1,184 +1,73 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
-import { fmtBoundaryWarning, lineHashes } from "../../src/hashline";
-import { useTestHome } from "../support/fixtures";
+import { describe, expect, it } from "vitest";
+import { applyEdits, resEdits, _lineHashesPure } from "../../src/hashline";
 
-const home = useTestHome();
+describe("boundary duplication [W_DUP] warning", () => {
+  it("emits [W_DUP] warning for trailing duplication (content_lines ends with surviving line)", () => {
+    // Model replaces lines 1-2, content_lines last non-empty line "after" matches next surviving "after"
+    const file = "before\nline1\nline2\nafter\n";
+    const hashes = _lineHashesPure(file);
 
-describe("fmtBoundaryWarning", () => {
-  it("formats a leading duplication warning with header and hashline window", async () => {
-    const resultLines = [
-      "before",
-      "before",
-      "new one",
-      "new two",
-      "after",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
+    const result = applyEdits(file, resEdits([
+      { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["new1", "new2", "after"] },
+    ]));
 
-    const output = fmtBoundaryWarning({
-      kind: "leading",
-      survivingContent: "before",
-      matchIndex: 1,
-      resultLines,
-      resultHashes,
-    });
-
-    expect(output).toContain("Boundary duplication (leading)");
-    expect(output).toContain(
-      "the first replacement line duplicated the previous line",
-    );
-    expect(output).toContain("│before");
-    expect(output).toContain("│new two");
-    for (const line of output.split("\n")) {
-      if (line.includes("│")) {
-        const hash = line.split("│")[0]!;
-        expect(hash).toMatch(/^[A-Za-z0-9_\-]{3}$/);
-      }
-    }
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("ends with") && w.includes("after"))).toBe(true);
+    // Content should NOT have been auto-fixed — the duplicate "after" stays
+    expect(result.content).toContain("new2\nafter\nafter");
   });
 
-  it("formats a trailing duplication warning with header and hashline window", async () => {
-    const resultLines = [
-      "before",
-      "old one",
-      "new trailing",
-      "new trailing",
-      "after",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
+  it("emits [W_DUP] warning for leading duplication (content_lines starts with preceding line)", () => {
+    const file = "before\nline1\nline2\nafter\n";
+    const hashes = _lineHashesPure(file);
 
-    const output = fmtBoundaryWarning({
-      kind: "trailing",
-      survivingContent: "new trailing",
-      matchIndex: 3,
-      resultLines,
-      resultHashes,
-    });
+    const result = applyEdits(file, resEdits([
+      { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["before", "new1", "new2"] },
+    ]));
 
-    expect(output).toContain("Boundary duplication (trailing)");
-    expect(output).toContain(
-      "the last replacement line duplicated the next line",
-    );
-    expect(output).toContain("│new trailing");
-    expect(output).toContain("│after");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with") && w.includes("before"))).toBe(true);
+    // Content should NOT have been auto-fixed — "before" stays duplicated
+    expect(result.content).toContain("before\nbefore\nnew1");
   });
 
-  it("clamps the window to file start when pair is near line 1", async () => {
-    const resultLines = [
-      "dup",
-      "dup",
-      "middle",
-      "end",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
+  it("does not emit [W_DUP] when there is no boundary match", () => {
+    const file = "before\nline1\nline2\nafter\n";
+    const hashes = _lineHashesPure(file);
 
-    const output = fmtBoundaryWarning({
-      kind: "leading",
-      survivingContent: "dup",
-      matchIndex: 0,
-      resultLines,
-      resultHashes,
-    });
+    const result = applyEdits(file, resEdits([
+      { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["new1", "new2"] },
+    ]));
 
-    const rows = output.split("\n").filter((l) => l.includes("│"));
-    expect(rows[0]).toContain("│dup");
-    expect(rows).toHaveLength(4); // 0..3 (pairStart=0, winStart=0, winEnd=min(3, 0+3)=3, so 0..3 = 4 rows)
+    expect(result.warnings?.some(w => w.startsWith("[W_DUP]")) ?? false).toBe(false);
   });
 
-  it("clamps the window to file end when pair is near the last line", async () => {
-    const resultLines = [
-      "start",
-      "middle",
-      "dup",
-      "dup",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
+  it("emits both trailing and leading [W_DUP] warnings when both boundaries match", () => {
+    const file = "before\nline1\nline2\nafter\n";
+    const hashes = _lineHashesPure(file);
 
-    const output = fmtBoundaryWarning({
-      kind: "trailing",
-      survivingContent: "dup",
-      matchIndex: 3,
-      resultLines,
-      resultHashes,
-    });
+    const result = applyEdits(file, resEdits([
+      { hash_range_inclusive: [hashes[1]!, hashes[2]!], content_lines: ["before", "new1", "after"] },
+    ]));
 
-    const rows = output.split("\n").filter((l) => l.includes("│"));
-    expect(rows[rows.length - 1]).toContain("│dup");
+    const dupWarnings = result.warnings?.filter(w => w.startsWith("[W_DUP]")) ?? [];
+    expect(dupWarnings).toHaveLength(2);
   });
 
-  it("picks the adjacent pair nearest matchIndex when multiple identical lines exist", async () => {
-    const resultLines = [
-      "dup",
-      "a",
-      "dup",
-      "dup",
-      "dup",
-      "b",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
+  it("warns for trailing } (structural delimiter)", () => {
+    // Two consecutive } at same indent — model includes one, next surviving is also }
+    const file = "if (a) {\n  x();\n}\n}\n";
+    const hashes = _lineHashesPure(file);
 
-    const output = fmtBoundaryWarning({
-      kind: "leading",
-      survivingContent: "dup",
-      matchIndex: 3,
-      resultLines,
-      resultHashes,
-    });
+    // Replace x() line, model includes } for the if block
+    // Next surviving line is also } (the outer closer) — warns
+    const result = applyEdits(file, resEdits([
+      { hash_range_inclusive: [hashes[1]!, hashes[1]!], content_lines: ["  z();", "}"] },
+    ]));
 
-    const rows = output.split("\n").filter((l) => l.includes("│"));
-    const rowContents = rows.map((r) => r.split("│")[1] ?? "");
-    expect(rowContents).toContain("a");
-    expect(rowContents).toContain("dup");
-    expect(rowContents).toContain("b");
-  });
-
-  it("falls back to matchIndex as pairStart when no adjacent pair is found", async () => {
-    const resultLines = [
-      "alpha",
-      "beta",
-      "gamma",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
-
-    const output = fmtBoundaryWarning({
-      kind: "leading",
-      survivingContent: "beta",
-      matchIndex: 1,
-      resultLines,
-      resultHashes,
-    });
-
-    expect(output).toContain("│beta");
-    expect(output).toContain("│alpha");
-    expect(output).toContain("│gamma");
-  });
-
-  it("includes exactly 2 lines of context before and after the pair", async () => {
-    const resultLines = [
-      "ctx1",
-      "ctx2",
-      "dup",
-      "dup",
-      "ctx3",
-      "ctx4",
-    ];
-    const resultHashes = await lineHashes(resultLines.join("\n"), home.testPath);
-
-    const output = fmtBoundaryWarning({
-      kind: "trailing",
-      survivingContent: "dup",
-      matchIndex: 2,
-      resultLines,
-      resultHashes,
-    });
-
-    const rows = output.split("\n").filter((l) => l.includes("│"));
-    expect(rows).toHaveLength(6); // 2 before + 2 dup + 2 after
-    expect(rows[0]).toContain("│ctx1");
-    expect(rows[1]).toContain("│ctx2");
-    expect(rows[2]).toContain("│dup");
-    expect(rows[3]).toContain("│dup");
-    expect(rows[4]).toContain("│ctx3");
-    expect(rows[5]).toContain("│ctx4");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("}"))).toBe(true);
+    // The } is kept (not silently stripped)
+    expect(result.content).toContain("  z();\n}\n}\n}");
   });
 });

--- a/test/core/hashline.apply.test.ts
+++ b/test/core/hashline.apply.test.ts
@@ -198,8 +198,8 @@ describe("applyEdits — noop detection", () => {
 	});
 });
 
-describe("applyEdits — auto-fix heuristics", () => {
-	it("auto-fixes leading duplication by stripping the first replacement line", async () => {
+describe("applyEdits — boundary duplication warnings", () => {
+	it("warns on leading duplication instead of auto-fixing", async () => {
 		const content = "before\nold one\nold two\nafter";
 		const edits: HEdit[] = [
 			{
@@ -210,13 +210,13 @@ describe("applyEdits — auto-fix heuristics", () => {
 
 		const result = applyEdits(content, edits);
 
-		expect(result.content).toBe("before\nnew one\nnew two\nafter");
-		expect(result.autoFixes).toHaveLength(1);
-		expect(result.autoFixes![0]!.kind).toBe("leading");
-		expect(result.autoFixes![0]!.removedLine).toBe("before");
+		// Duplicate "before" is kept (not auto-fixed)
+		expect(result.content).toBe("before\nbefore\nnew one\nnew two\nafter");
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with") && w.includes("before"))).toBe(true);
 	});
 
-	it("auto-fixes trailing duplication by stripping the last replacement line", async () => {
+	it("warns on trailing duplication instead of auto-fixing", async () => {
 		const content = "before\nold one\nold two\nafter";
 		const edits: HEdit[] = [
 			{
@@ -227,10 +227,10 @@ describe("applyEdits — auto-fix heuristics", () => {
 
 		const result = applyEdits(content, edits);
 
-		expect(result.content).toBe("before\nnew one\nnew two\nafter");
-		expect(result.autoFixes).toHaveLength(1);
-		expect(result.autoFixes![0]!.kind).toBe("trailing");
-		expect(result.autoFixes![0]!.removedLine).toBe("after");
+		// Duplicate "after" is kept (not auto-fixed)
+		expect(result.content).toBe("before\nnew one\nnew two\nafter\nafter");
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("ends with") && w.includes("after"))).toBe(true);
 	});
 });
 

--- a/test/core/indent-dup.test.ts
+++ b/test/core/indent-dup.test.ts
@@ -4,26 +4,28 @@ import { useTestHome } from "../support/fixtures";
 
 const home = useTestHome();
 
-describe("indentation difference in boundary auto-fix", () => {
-  it("auto-fixes leading duplication when indentation matches exactly", async () => {
+describe("indentation difference in boundary warning", () => {
+  it("warns on leading duplication when indentation matches exactly (duplicate kept)", async () => {
     const file = "  foo\nbar\n  baz";
     const hashes = await lineHashes(file, home.testPath);
     const result = applyEdits(file, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[1]!], content_lines: ["  foo", "  bar"] },
     ]));
-    expect(result.content).toBe("  foo\n  bar\n  baz");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    // Duplicate is kept (not auto-fixed) — "  foo" appears twice
+    expect(result.content).toBe("  foo\n  foo\n  bar\n  baz");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with"))).toBe(true);
   });
 
-  it("auto-fixes leading duplication when both indentation and content match exactly", async () => {
+  it("warns on leading duplication when both indentation and content match exactly (duplicate kept)", async () => {
     const file = "  foo\n  bar\n  baz";
     const hashes = await lineHashes(file, home.testPath);
     const result = applyEdits(file, resEdits([
       { hash_range_inclusive: [hashes[1]!, hashes[1]!], content_lines: ["  foo", "  new"] },
     ]));
-    expect(result.content).toBe("  foo\n  new\n  baz");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    // Duplicate is kept
+    expect(result.content).toBe("  foo\n  foo\n  new\n  baz");
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some(w => w.startsWith("[W_DUP]") && w.includes("starts with"))).toBe(true);
   });
 });

--- a/test/integration/boundary-dup-correction.test.ts
+++ b/test/integration/boundary-dup-correction.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { readFile } from "fs/promises";
 import { withTempFile, setupIntegrationTest, getText, extractHash } from "../support/fixtures";
 
-describe("boundary duplication auto-fix", () => {
-  it("trailing }: auto-fix strips duplicate, file is correct after one edit", async () => {
+describe("boundary duplication [W_DUP] warning (no auto-fix)", () => {
+  it("trailing }: warns, duplicate kept in file", async () => {
     const file = "function foo() {\n  const x = 1;\n  return x;\n}\n";
     await withTempFile("sample.ts", file, async ({ cwd, path }) => {
       const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
@@ -15,7 +15,7 @@ describe("boundary duplication auto-fix", () => {
       const line2Hash = extractHash(lines1.find(l => l.includes("│  const x = 1;"))!);
       const line3Hash = extractHash(lines1.find(l => l.includes("│  return x;"))!);
 
-      await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "sample.ts",
@@ -29,12 +29,20 @@ describe("boundary duplication auto-fix", () => {
         ctx,
       );
 
+      const resultText = getText(result);
+      // Should NOT be a noop — the edit applied
+      expect(resultText).not.toContain("No changes made");
+      // Warning should be present
+      expect(resultText).toMatch(/\[W_DUP\]/);
+      expect(resultText).toMatch(/ends with/);
+
+      // File has a duplicate } (not silently stripped)
       const content = await readFile(path, "utf-8");
-      expect(content).toBe("function foo() {\n  const y = 2;\n  return y;\n}\n");
+      expect(content).toBe("function foo() {\n  const y = 2;\n  return y;\n}\n}\n");
     });
   });
 
-  it("trailing });: auto-fix strips duplicate, file is correct after one edit", async () => {
+  it("trailing });: warns, duplicate kept in file", async () => {
     const file = 'app.get("/api", (req, res) => {\n  const data = fetchData();\n  res.json(data);\n});\n';
     await withTempFile("server.ts", file, async ({ cwd, path }) => {
       const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
@@ -44,7 +52,7 @@ describe("boundary duplication auto-fix", () => {
       const line2Hash = extractHash(lines1.find(l => l.includes("│  const data"))!);
       const line3Hash = extractHash(lines1.find(l => l.includes("│  res.json"))!);
 
-      await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "server.ts",
@@ -58,12 +66,15 @@ describe("boundary duplication auto-fix", () => {
         ctx,
       );
 
+      const resultText = getText(result);
+      expect(resultText).toMatch(/\[W_DUP\]/);
+
       const content = await readFile(path, "utf-8");
-      expect(content).toBe('app.get("/api", (req, res) => {\n  const result = processData();\n  res.json(result);\n});\n');
+      expect(content).toBe('app.get("/api", (req, res) => {\n  const result = processData();\n  res.json(result);\n});\n});\n');
     });
   });
 
-  it("leading: auto-fix strips duplicate, file is correct after one edit", async () => {
+  it("leading: warns, duplicate kept in file", async () => {
     const file = "before();\nif (ok) {\n  run();\n}\nafter();\n";
     await withTempFile("logic.ts", file, async ({ cwd, path }) => {
       const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
@@ -73,7 +84,7 @@ describe("boundary duplication auto-fix", () => {
       const line2Hash = extractHash(lines1.find(l => l.includes("│if (ok)"))!);
       const line3Hash = extractHash(lines1.find(l => l.includes("│  run();"))!);
 
-      await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "logic.ts",
@@ -87,12 +98,15 @@ describe("boundary duplication auto-fix", () => {
         ctx,
       );
 
+      const resultText = getText(result);
+      expect(resultText).toMatch(/\[W_DUP\]/);
+
       const content = await readFile(path, "utf-8");
-      expect(content).toBe("before();\nif (ok) {\n  runSafe();\n}\nafter();\n");
+      expect(content).toBe("before();\nbefore();\nif (ok) {\n  runSafe();\n}\nafter();\n");
     });
   });
 
-  it("trailing } with multiple identical lines: auto-fix preserves correct hash", async () => {
+  it("trailing } with multiple identical lines: warns, duplicate kept", async () => {
     const file = "if (a) {\n  x();\n}\nif (b) {\n  y();\n}\nif (c) {\n  z();\n}\n";
     await withTempFile("multi.ts", file, async ({ cwd, path }) => {
       const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
@@ -103,11 +117,7 @@ describe("boundary duplication auto-fix", () => {
       const line4Hash = extractHash(lines1.find(l => l.includes("│if (b)"))!);
       const line5Hash = extractHash(lines1.find(l => l.includes("│  y();"))!);
 
-      const braceLines1 = lines1.filter(l => l.endsWith("│}"));
-      expect(braceLines1.length).toBe(3);
-      const survivingBraceHash = extractHash(braceLines1[1]!);
-
-      await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "multi.ts",
@@ -121,19 +131,16 @@ describe("boundary duplication auto-fix", () => {
         ctx,
       );
 
-      const read2 = await readTool.execute("r2", { path: "multi.ts" }, undefined, undefined, ctx);
-      const lines2 = getText(read2).split("\n");
-      const braceLines2 = lines2.filter(l => l.endsWith("│}"));
-      expect(braceLines2.length).toBe(3);
+      const resultText = getText(result);
+      expect(resultText).toMatch(/\[W_DUP\]/);
 
-      const matchingBraces = braceLines2.filter(l => extractHash(l) === survivingBraceHash);
-      expect(matchingBraces.length).toBe(1);
-      const survivingIndex = braceLines2.findIndex(l => extractHash(l) === survivingBraceHash);
-      expect(survivingIndex).toBe(1);
+      // The duplicate } is kept — file now has extra }
+      const content = await readFile(path, "utf-8");
+      expect(content).toBe("if (a) {\n  x();\n}\nif (b) {\n  yNew();\n}\n}\nif (c) {\n  z();\n}\n");
     });
   });
 
-  it("4th } before edit range: auto-fix strips duplicate, edit becomes noop", async () => {
+  it("4th } before edit range: warns, duplicate kept (no longer a noop)", async () => {
     const file = [
       "if (a) {", "  x();", "}",
       "if (b) {", "  y();", "}",
@@ -151,7 +158,7 @@ describe("boundary duplication auto-fix", () => {
       const fooHash = extractHash(lines1.find(l => l.includes("│foo();"))!);
       const barHash = extractHash(lines1.find(l => l.includes("│bar();"))!);
 
-      const edit1 = await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "fourth.ts",
@@ -162,13 +169,16 @@ describe("boundary duplication auto-fix", () => {
         ctx,
       );
 
-      const edit1Text = getText(edit1);
-      expect(edit1Text).toContain("No changes made");
-      expect(edit1Text).toContain("noop");
+      const resultText = getText(result);
+      // Should NOT be a noop — the edit applied (duplicate } kept)
+      expect(resultText).not.toContain("No changes made");
+      expect(resultText).toMatch(/\[W_DUP\]/);
 
-      const { readFile } = await import("fs/promises");
+      // File has an extra } (not silently stripped) — the duplicate stays
       const content = await readFile(path, "utf-8");
-      expect(content).toBe(file);
+      // Original ends with ...bar();\n}\n
+      // After edit: ...bar();\n}\n}\n (duplicate } kept, original } still there)
+      expect(content.endsWith("bar();\n}\n}\n")).toBe(true);
     });
   });
 });

--- a/test/tools/edit.noop-warning.test.ts
+++ b/test/tools/edit.noop-warning.test.ts
@@ -24,12 +24,12 @@ describe("edit tool noop + warnings", () => {
     });
   });
 
-  it("auto-fixes trailing duplicate silently, file is correct", async () => {
+  it("warns on trailing duplicate instead of auto-fixing silently", async () => {
     await withTempFile("sample.ts", "aaa\nbbb\nccc\n", async ({ cwd, path }) => {
       const { ctx, editTool } = setupIntegrationTest(cwd);
       const hashes = await lineHashes("aaa\nbbb\nccc\n", home.testPath);
 
-      await editTool.execute(
+      const result = await editTool.execute(
         "e1",
         {
           path: "sample.ts",
@@ -40,9 +40,13 @@ describe("edit tool noop + warnings", () => {
         ctx,
       );
 
+      // Should NOT be a noop
+      expect(result.details.classification).not.toBe("noop");
+
       const { readFile } = await import("fs/promises");
       const content = await readFile(path, "utf-8");
-      expect(content).toBe("aaa\nBBB\nccc\n");
+      // Duplicate ccc is kept (not auto-fixed)
+      expect(content).toBe("aaa\nBBB\nccc\nccc\n");
     });
   });
 });


### PR DESCRIPTION
## Problem

The boundary-duplication auto-fix silently stripped the last/first line of content_lines when it matched the adjacent surviving line (see issue #12). This was meant to compensate for LLMs frequently duplicating closing delimiters, but it cannot distinguish coincidental structural matches from genuine duplicates. The silent strip causes invisible structural breakage.

## Changes

- Remove silent auto-fix logic in applyEdits
- Keep checkBoundaryDup detection; convert to terse [W_DUP] warning
- Sharpen boundary-checking rule in prompt/guidelines
- Add 'Moving blocks' pattern (bulk-mode atomic move) to guidelines
- Remove unused warnings parameter from valEdits (dead after auto-fix removal)
- Trim BDupWarn to only used fields

The [W_DUP] warning never silently alters structure. The warning is ~one line of output. Detection code kept, auto-fix/splice/re-validate removed — net code reduction.