### PR TITLE
FIX: Handle Windows EPERM when target is open

### DIFF
--- a/src/fs-write.ts
+++ b/src/fs-write.ts
@@ -120,6 +120,14 @@ export async function writeAtomic(
         throw error;
       }
     }
+    if (process.platform === "win32" && errCode(error) === "EPERM") {
+      try {
+        await writeFile(targetPath, content, "utf-8");
+        return;
+      } finally {
+        try { await rm(tempPath, { force: true }); } catch {}
+      }
+    }
     try { await rm(tempPath, { force: true }); } catch {}
     throw error;
   }

--- a/test/tools/fs-write.test.ts
+++ b/test/tools/fs-write.test.ts
@@ -7,6 +7,7 @@ import {
   symlink,
   link,
   chmod,
+  open,
 } from "fs/promises";
 import { join } from "path";
 import { resolveTarget, writeAtomic } from "../../src/fs-write";
@@ -97,6 +98,20 @@ describe("writeAtomic", () => {
       await writeAtomic(filePath, "new content");
       const content = await readFile(filePath, "utf-8");
       expect(content).toBe("new content");
+    });
+  });
+
+  it("overwrites a file held open for reading", async () => {
+    await withTempDir("fs-write-test-", async (dir) => {
+      const filePath = join(dir, "held.txt");
+      await writeFile(filePath, "old content");
+      const handle = await open(filePath, "r");
+      try {
+        await writeAtomic(filePath, "new content");
+      } finally {
+        await handle.close();
+      }
+      expect(await readFile(filePath, "utf-8")).toBe("new content");
     });
   });
 


### PR DESCRIPTION
## Summary

- Fall back to an in-place write on Windows when the atomic `rename()` fails with `EPERM`.
- Keep POSIX behavior and non-`EPERM` errors unchanged.
- Always clean up the temporary file after the fallback.
- Add a regression test that holds the target open for reading while overwriting it.

## Why

Windows cannot rename over an existing target when another open handle does not allow `FILE_SHARE_DELETE`. This affects editors, indexers, antivirus software, and concurrent Pi processes.

Retrying does not help for long-lived handles. The fallback writes through the existing inode, trading atomicity only on the Windows path that would otherwise fail completely.

## Testing

- `vitest run test/tools/fs-write.test.ts` — 15 passed
- `npm run typecheck` — passed
- ESLint on changed files — passed
- `git diff --check` — passed
- Full suite on Windows: 642 passed; 15 unrelated failures remain from existing POSIX path/mode assumptions and SQLite cleanup locks.

Closes #16
