### PR TITLE
feat: show line numbers in the TUI for read/replace/undo results

### DIFF
--- a/scripts/hashline-smoke.mjs
+++ b/scripts/hashline-smoke.mjs
@@ -1,0 +1,125 @@
+// jiti smoke test for the localized pi-hashline-edit-pro fork.
+// Verifies: factory registers read/replace/undo_last_replace; read and
+// replace renderResult produce line-numbered output for the TUI.
+import { createJiti } from "/Users/hty/.pi/agent/npm/node_modules/jiti/lib/jiti.mjs";
+
+const jiti = createJiti(import.meta.url, {
+  moduleCache: false,
+  alias: {
+    "@earendil-works/pi-coding-agent":
+      "/Users/hty/.nvm/versions/node/v22.19.0/lib/node_modules/@earendil-works/pi-coding-agent/dist/index.js",
+  },
+});
+
+const mod = await jiti.import(
+  "/Users/hty/.pi/agent/extensions/pi-hashline-edit-pro/index.ts",
+);
+const factory = mod.default ?? mod;
+
+const registered = new Map();
+const fakePi = {
+  on() {},
+  events: { on() { return () => {}; } },
+  getActiveTools: () => [],
+  setActiveTools() {},
+  registerTool(def) { registered.set(def.name, def); },
+  registerCommand() {},
+};
+
+factory(fakePi);
+
+const names = [...registered.keys()].sort();
+console.log("registered tools:", names.join(", "));
+
+const readDef = registered.get("read");
+const replaceDef = registered.get("replace");
+const undoDef = registered.get("undo_last_replace");
+
+const ok = (cond, msg) => {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+  console.log(`ok: ${msg}`);
+};
+
+ok(typeof readDef.renderResult === "function", "read has renderResult");
+ok(typeof replaceDef.renderResult === "function", "replace has renderResult");
+ok(typeof undoDef.renderResult === "function", "undo_last_replace has renderResult");
+
+const theme = { fg: (_color, s) => s };
+const stripAnsi = (s) => s;
+
+// --- read renderResult with offset=5 ---
+const readResult = {
+  content: [
+    {
+      type: "text",
+      text: "aB3│foo\nszJ│bar\n[Showing lines 5-6 of 100. Use offset=7 to continue.]",
+    },
+  ],
+};
+const readComp = readDef.renderResult(
+  readResult,
+  { expanded: true },
+  theme,
+  { args: { offset: 5 }, isError: false, lastComponent: undefined },
+);
+const readLines = readComp.render(200).join("\n").split("\n").map((l) => l.trimEnd());
+console.log("read render output:");
+for (const l of readLines) console.log(`  ${JSON.stringify(l)}`);
+ok(readLines[0] === "5 │ aB3│foo", "read row 1 numbered with offset");
+ok(readLines[1] === "6 │ szJ│bar", "read row 2 numbered");
+ok(readLines[2].includes("Showing lines 5-6"), "pagination hint passed through");
+
+// --- undo renderResult with applied diff ---
+const undoResult = {
+  content: [{ type: "text", text: "Undone last replace on src/a.ts." }],
+  details: {
+    diff: " aB3│alpha\n-szJ│beta\n+kQm│BETA\n e8m│gamma",
+    diffLineNumbers: [1, 2, 2, 3],
+    metrics: { classification: "applied", added_lines: 1, removed_lines: 1 },
+  },
+};
+const undoComp = undoDef.renderResult(
+  undoResult,
+  { expanded: true },
+  theme,
+  { isError: false, lastComponent: undefined, state: {} },
+);
+const undoLines = undoComp.render(200).join("\n").split("\n").map((l) => l.trimEnd());
+console.log("undo diff render output:");
+for (const l of undoLines) console.log(`  ${JSON.stringify(l)}`);
+ok(undoLines[1] === "2 │ -szJ│beta", "undo removed row shows old line number");
+ok(undoLines[2] === "2 │ +kQm│BETA", "undo added row shows new line number");
+
+// --- read renderResult without offset (default start 1) ---
+const readComp2 = readDef.renderResult(
+  { content: [{ type: "text", text: "kQm│x\n"}], details: {} },
+  { expanded: true },
+  theme,
+  { args: {}, isError: false, lastComponent: undefined },
+);
+ok(readComp2.render(200).join("\n").split("\n").map((l) => l.trimEnd())[0] === "1 │ kQm│x", "read defaults to line 1");
+
+// --- replace renderResult with applied diff ---
+const replaceResult = {
+  content: [{ type: "text", text: "Successfully replaced in src/a.ts." }],
+  details: {
+    diff: " aB3│alpha\n-szJ│beta\n+kQm│BETA\n e8m│gamma",
+    diffLineNumbers: [1, 2, 2, 3],
+    metrics: { classification: "applied", added_lines: 1, removed_lines: 1 },
+  },
+};
+const replaceComp = replaceDef.renderResult(
+  replaceResult,
+  { expanded: true },
+  theme,
+  { isError: false, lastComponent: undefined, state: {} },
+);
+const diffLines = replaceComp.render(200).join("\n").split("\n").map((l) => l.trimEnd());
+console.log("replace diff render output:");
+for (const l of diffLines) console.log(`  ${JSON.stringify(l)}`);
+ok(diffLines[0] === "1 │  aB3│alpha", "diff context row numbered");
+ok(diffLines[1] === "2 │ -szJ│beta", "diff removed row shows old line number");
+ok(diffLines[2] === "2 │ +kQm│BETA", "diff added row shows new line number");
+ok(diffLines[3] === "3 │  e8m│gamma", "diff context row 2 numbered");
+
+console.log("\nALL SMOKE CHECKS PASSED");

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,10 +1,11 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
 import {
 	createReadTool,
 	formatSize,
 	truncateHead,
 	type TruncationResult,
 } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { MAX_READ_LINE_BYTES } from "./constants";
 import { loadFileKindAndText } from "./file-kind";
@@ -21,6 +22,36 @@ const R_DESC = loadP("../prompts/read.md");
 
 const R_SNIPPET = loadP("../prompts/read-snippet.md");
 
+const HL_ROW_RE = /^[A-Za-z0-9]{3}│/;
+
+type ReadFgT = Pick<Theme, "fg">;
+
+function fmtNumberedRead(
+	text: string,
+	startLine: number,
+	theme: ReadFgT,
+): string {
+	const lines = text.split("\n");
+	let rowCount = 0;
+	for (const line of lines) {
+		if (HL_ROW_RE.test(line)) rowCount++;
+	}
+	const lastShown = startLine + Math.max(0, rowCount - 1);
+	const width = String(lastShown).length;
+	let current = startLine;
+	const out: string[] = [];
+	for (const line of lines) {
+		if (HL_ROW_RE.test(line)) {
+			out.push(
+				`${theme.fg("dim", `${String(current).padStart(width)} │ `)}${theme.fg("toolOutput", line)}`,
+			);
+			current++;
+		} else {
+			out.push(theme.fg("toolOutput", line));
+		}
+	}
+	return out.join("\n");
+}
 function readGuide(): string[] {
 	return loadGuide("../prompts/read-guidelines.md");
 }
@@ -169,6 +200,31 @@ export function regRead(pi: ExtensionAPI): void {
 				}),
 			),
 		}),
+
+		renderResult(result, _options, theme, context) {
+			const text =
+				context.lastComponent instanceof Text
+					? context.lastComponent
+					: new Text("", 0, 0);
+			const args = (context.args ?? {}) as { offset?: number };
+			const startLine =
+				typeof args.offset === "number" && args.offset > 0
+					? args.offset
+					: 1;
+			const content = (result.content ?? [])
+				.filter(
+					(entry): entry is { type: "text"; text: string } =>
+						entry.type === "text" && typeof entry.text === "string",
+				)
+				.map((entry) => entry.text)
+				.join("\n");
+			text.setText(
+				context.isError
+					? theme.fg("error", content)
+					: fmtNumberedRead(content, startLine, theme),
+			);
+			return text;
+		},
 
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const rawPath = params.path;

--- a/src/replace-diff.ts
+++ b/src/replace-diff.ts
@@ -56,12 +56,14 @@ export function genDiff(
   newContent: string,
   contextLines = 2,
   newContentHashes?: string[],
-): { diff: string; firstChangedLine: number | undefined } {
+): { diff: string; firstChangedLine: number | undefined; rowLines: (number | undefined)[] } {
   const effectiveNewHashes = newContentHashes ?? _lineHashesPure(newContent);
 
   const parts = Diff.diffLines(oldContent, newContent);
   const output: string[] = [];
+  const rowLines: (number | undefined)[] = [];
   let newLineNum = 1;
+  let oldLineNum = 1;
   let lastWasChange = false;
   let firstChangedLine: number | undefined;
 
@@ -77,9 +79,12 @@ export function genDiff(
         if (part.added) {
           const hash = effectiveNewHashes[newLineNum - 1];
           output.push(fmtDiffLine("+", displayLines[k]!, hash));
+          rowLines.push(newLineNum);
           newLineNum++;
         } else {
           output.push(fmtDiffLine("-", displayLines[k]!, undefined));
+          rowLines.push(oldLineNum);
+          oldLineNum++;
         }
       }
       lastWasChange = true;
@@ -106,23 +111,30 @@ export function genDiff(
 
       if (skipStart > 0) {
         output.push(" ...");
+        rowLines.push(undefined);
         newLineNum += skipStart;
+        oldLineNum += skipStart;
       }
       for (const line of linesToShow) {
         if (isEllipsisMarker(line)) {
           output.push(" ...");
+          rowLines.push(undefined);
           newLineNum += skipMiddle;
+          oldLineNum += skipMiddle;
           continue;
         }
         const hash = effectiveNewHashes[newLineNum - 1];
         output.push(fmtDiffLine(" ", line, hash));
+        rowLines.push(newLineNum);
         newLineNum++;
+        oldLineNum++;
       }
     } else {
       newLineNum += displayLines.length;
+      oldLineNum += displayLines.length;
     }
     lastWasChange = false;
   }
 
-  return { diff: output.join("\n"), firstChangedLine };
+  return { diff: output.join("\n"), firstChangedLine, rowLines };
 }

--- a/src/replace-render.ts
+++ b/src/replace-render.ts
@@ -10,8 +10,9 @@ export type MdTheme = Pick<
 	"fg" | "bold" | "italic" | "underline" | "strikethrough"
 >;
 
-export type RPreview = { diff: string } | { error: string };
-
+export type RPreview =
+  | { diff: string; diffLineNumbers?: (number | undefined)[] }
+  | { error: string };
 export type RRState = {
 	argsKey?: string;
 	preview?: RPreview;
@@ -48,15 +49,37 @@ export function getPreviewInput(
 	return request;
 }
 
+const DIFF_MARKER_RE = /^(?:\s*\d+\s*│\s*)?([+-])/;
+
 export function colorLines(lines: string[], theme: FgT): string[] {
 	return lines.map((line) => {
-		if (line.startsWith("+") && !line.startsWith("+++")) {
+		const marker = line.match(DIFF_MARKER_RE)?.[1];
+		if (marker === "+" && !line.startsWith("+++")) {
 			return theme.fg("success", line);
 		}
-		if (line.startsWith("-") && !line.startsWith("---")) {
+		if (marker === "-" && !line.startsWith("---")) {
 			return theme.fg("error", line);
 		}
 		return theme.fg("dim", line);
+	});
+}
+
+export function numberedDiffRows(
+	diff: string,
+	lineNumbers: (number | undefined)[] | undefined,
+): string[] {
+	const rows = diff.split("\n");
+	if (!lineNumbers) return rows;
+	const present = lineNumbers.filter((n): n is number => n !== undefined);
+	const width =
+		present.length > 0
+			? Math.max(...present.map((n) => String(n).length))
+			: 1;
+	const blankPrefix = " ".repeat(width + 3);
+	return rows.map((row, index) => {
+		const num = lineNumbers[index];
+		if (num === undefined) return `${blankPrefix}${row}`;
+		return `${String(num).padStart(width)} │ ${row}`;
 	});
 }
 
@@ -64,8 +87,9 @@ export function fmtPreview(
 	diff: string,
 	expanded: boolean,
 	theme: FgT,
+	lineNumbers?: (number | undefined)[],
 ): string {
-	const lines = diff.split("\n");
+	const lines = numberedDiffRows(diff, lineNumbers);
 	const maxLines = expanded ? 40 : 16;
 	const shown = colorLines(lines.slice(0, maxLines), theme);
 
@@ -77,8 +101,12 @@ export function fmtPreview(
 	return shown.join("\n");
 }
 
-export function fmtResult(diff: string, theme: FgT): string {
-	return colorLines(diff.split("\n"), theme).join("\n");
+export function fmtResult(
+	diff: string,
+	theme: FgT,
+	lineNumbers?: (number | undefined)[],
+): string {
+	return colorLines(numberedDiffRows(diff, lineNumbers), theme).join("\n");
 }
 
 export function fmtCall(
@@ -104,7 +132,7 @@ export function fmtCall(
 	}
 
 	if (state.preview.diff) {
-		text += `\n\n${fmtPreview(state.preview.diff, expanded, theme)}`;
+		text += `\n\n${fmtPreview(state.preview.diff, expanded, theme, state.preview.diffLineNumbers)}`;
 	}
 	return text;
 }
@@ -144,7 +172,7 @@ export function buildAppliedText(
 	const sections: string[] = [];
 
 	if (details?.diff) {
-		sections.push(fmtResult(details.diff, theme));
+		sections.push(fmtResult(details.diff, theme, details.diffLineNumbers));
 	}
 
 	const warnings = extractWarnings(text);

--- a/src/replace-response.ts
+++ b/src/replace-response.ts
@@ -155,6 +155,7 @@ export function buildChanged(input: SuccessInput): TResult {
     content: [{ type: "text", text }],
     details: {
       diff: diffResult.diff,
+      diffLineNumbers: diffResult.rowLines,
       firstChangedLine:
         editMeta.firstChangedLine ?? diffResult.firstChangedLine,
       snapshotId,

--- a/src/replace-undo.ts
+++ b/src/replace-undo.ts
@@ -1,4 +1,5 @@
 import { readFile } from "fs/promises";
+import { Text } from "@earendil-works/pi-tui";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -10,6 +11,8 @@ import { toLF, stripBOM, genDiff, restoreEndings, type LineEnding } from "./repl
 import { cntDiff, splitLines, errCode } from "./utils";
 import { loadP, loadGuide } from "./prompts";
 import { buildMetrics } from "./replace-response";
+import { buildAppliedText, getResultText } from "./replace-render";
+import type { ReplaceDetails } from "./replace";
 import { changedRange } from "./hashline";
 export interface UndoEntry {
   content: string;
@@ -97,6 +100,25 @@ export function regReplaceUndo(pi: ExtensionAPI): void {
       }),
     }),
 
+    renderResult(result, _options, theme, context) {
+      const text =
+        context.lastComponent instanceof Text
+          ? context.lastComponent
+          : new Text("", 0, 0);
+      const typedResult = result as {
+        content?: Array<{ type: string; text?: string }>;
+        details?: ReplaceDetails;
+      };
+      const renderedText = getResultText(typedResult);
+      if (context.isError) {
+        text.setText(renderedText ? `\n${theme.fg("error", renderedText)}` : "");
+        return text;
+      }
+      const appliedText = buildAppliedText(renderedText, typedResult.details, theme);
+      text.setText(appliedText ?? renderedText ?? "");
+      return text;
+    },
+
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const path = params.path;
       const absolutePath = toCwd(path, ctx.cwd);
@@ -157,13 +179,12 @@ export function regReplaceUndo(pi: ExtensionAPI): void {
         const linesAddedByReplace = cntDiff(diffResult.diff, "+");
         const linesRemovedByReplace = cntDiff(diffResult.diff, "-");
         const restoredRange = changedRange(currentNormalized, undo.content);
-        const undoDiff = genDiff(currentNormalized, undo.content, 1, undo.hashes).diff;
+        const undoDiff = genDiff(currentNormalized, undo.content, 1, undo.hashes);
 
         await writeAtomic(
           mutationTargetPath,
           undo.bom + restoreEndings(undo.content, undo.originalEnding),
         );
-
         try {
           const store = await loadHashStore();
           upsertSnapshot(store, mutationTargetPath, contentChecksum(undo.content), splitLines(undo.content).length, undo.hashes);
@@ -193,7 +214,8 @@ export function regReplaceUndo(pi: ExtensionAPI): void {
             },
           ],
           details: {
-            diff: undoDiff,
+            diff: undoDiff.diff,
+            diffLineNumbers: undoDiff.rowLines,
             metrics: buildMetrics({
               classification: "applied",
               editsAttempted: 1,

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -75,6 +75,7 @@ export type ReqParams = {
 
 export type ReplaceDetails = {
   diff: string;
+  diffLineNumbers?: (number | undefined)[];
   firstChangedLine?: number;
   snapshotId?: string;
   classification?: "noop";
@@ -264,8 +265,8 @@ export async function compPreview(
         error: `No changes made to ${path}. The edit produced identical content.`,
       };
     }
-
-    return { diff: genDiff(originalNormalized, result, 4, resultHashes).diff };
+    const diffResult = genDiff(originalNormalized, result, 4, resultHashes);
+    return { diff: diffResult.diff, diffLineNumbers: diffResult.rowLines };
   } catch (error: unknown) {
     return { error: error instanceof Error ? error.message : String(error) };
   }

--- a/test/core/edit-diff.linenumbers.test.ts
+++ b/test/core/edit-diff.linenumbers.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { genDiff } from "../../src/replace-diff";
+import { numberedDiffRows } from "../../src/replace-render";
+import { initHasher } from "../../src/hashline";
+
+beforeAll(async () => {
+  await initHasher();
+});
+
+describe("genDiff rowLines", () => {
+  it("numbers added rows by new-file line and removed rows by old-file line", () => {
+    const { diff, rowLines } = genDiff("alpha\nbeta\ngamma", "alpha\nBETA\ngamma");
+    const rows = diff.split("\n");
+    expect(rows.length).toBe(rowLines.length);
+    expect(rows[0]).toMatch(/^ [A-Za-z0-9]{3}│alpha$/);
+    expect(rowLines[0]).toBe(1);
+    expect(rows[1]).toMatch(/^- {3}│beta$/);
+    expect(rowLines[1]).toBe(2);
+    expect(rows[2]).toMatch(/^\+[A-Za-z0-9]{3}│BETA$/);
+    expect(rowLines[2]).toBe(2);
+    expect(rows[3]).toMatch(/^ [A-Za-z0-9]{3}│gamma$/);
+    expect(rowLines[3]).toBe(3);
+  });
+
+  it("marks ellipsis rows as undefined and keeps following rows numbered", () => {
+    const lines: string[] = [];
+    for (let i = 1; i <= 1000; i++) lines.push("line " + i);
+    const before = "BEFORE\n" + lines.join("\n") + "\nAFTER";
+    const after = "BEFORE_CHANGED\n" + lines.join("\n") + "\nAFTER_CHANGED";
+
+    const { diff, rowLines } = genDiff(before, after, 4);
+    const rows = diff.split("\n");
+    expect(rows.length).toBe(rowLines.length);
+
+    const ellipsisIdx = rows.findIndex((l) => l.trim() === "...");
+    expect(ellipsisIdx).toBeGreaterThan(0);
+    expect(rowLines[ellipsisIdx]).toBeUndefined();
+
+    const beforeLast = rowLines[ellipsisIdx - 1]!;
+    const afterFirst = rowLines[ellipsisIdx + 1]!;
+    expect(afterFirst).toBeGreaterThan(beforeLast);
+
+    const lastRowNum = rowLines[rowLines.length - 1]!;
+    expect(rows[rows.length - 1]).toContain("AFTER_CHANGED");
+    expect(lastRowNum).toBeGreaterThan(1000);
+  });
+});
+
+describe("numberedDiffRows", () => {
+  it("prefixes rows with right-aligned line numbers", () => {
+    const diff = [
+      " aB3│alpha",
+      "+szJ│BETA",
+      "-   │beta",
+      " kQm│gamma",
+    ].join("\n");
+    const out = numberedDiffRows(diff, [1, 2, 2, 3]);
+    expect(out).toEqual([
+      "1 │  aB3│alpha",
+      "2 │ +szJ│BETA",
+      "2 │ -   │beta",
+      "3 │  kQm│gamma",
+    ]);
+  });
+
+  it("aligns the number column to the widest number", () => {
+    const diff = ["+aB3│x", " kQm│y"].join("\n");
+    const out = numberedDiffRows(diff, [9, 10]);
+    expect(out).toEqual([" 9 │ +aB3│x", "10 │  kQm│y"]);
+  });
+
+  it("keeps the diff content column aligned for ellipsis rows", () => {
+    const diff = [" ...", "+szJ│x"].join("\n");
+    const out = numberedDiffRows(diff, [undefined, 42]);
+    expect(out).toEqual(["      ...", "42 │ +szJ│x"]);
+  });
+
+  it("returns rows unchanged when line numbers are absent", () => {
+    const diff = "+szJ│x\n kQm│y";
+    expect(numberedDiffRows(diff, undefined)).toEqual(diff.split("\n"));
+  });
+});


### PR DESCRIPTION
## Why

When a human reviews a pi conversation (diff review, debugging, or cross-referencing with compiler/linter output), the hashline protocol shows every line as `HASH│content` — but the hash is meaningless to a human eye. Line numbers let the reviewer instantly locate the corresponding spot in their editor (`sed -n '42p'`, grep results, error messages) without counting lines by hand.

This is a **display-only change**: the line numbers are rendered by the TUI `renderResult` layer and **never reach the LLM**. The model-visible tool text stays pure `HASH│content` / `+HASH│…` / `-   │…`, so the replace protocol, the anchor semantics, and the autocorrection logic are completely untouched. No risk of a model copying `HASH│12│content` into `content_lines`.

## What

- `read` results: every hashline row is prefixed with its line number in the TUI (` 12 │ aB3│content`), seeded by `context.args.offset` for paged reads.
- `replace` / `undo_last_replace` results: the diff rows shown in the TUI carry a right-aligned line-number column (` 2 │ +szJ│…`). Added/context rows show the new-file line number; removed rows show the old-file line number.
- `undo_last_replace` previously had no `renderResult` at all — it now renders its post-edit diff with the same numbering.

## How

- `genDiff()` returns `rowLines` parallel to the diff rows (new-file numbers for `+`/context rows, old-file numbers for `-` rows, `undefined` for ellipsis rows).
- `replace`/`undo_last_replace` expose it as `details.diffLineNumbers` — TUI-only metadata that never enters the model context (the `tool_result` handler still forwards only `details.diff` to the model).
- `read` gains a `renderResult` that numbers hashline rows via `fmtNumberedRead()`.
- `colorLines` now detects the `+`/`-` marker after the optional number prefix, keeping the success/error coloring in the numbered view.

## Tests

- Unit tests for `genDiff().rowLines` and `numberedDiffRows()` (`test/core/edit-diff.linenumbers.test.ts`).
- A jiti smoke script (`scripts/hashline-smoke.mjs`) that loads the extension against the real pi loader aliases and asserts the `renderResult` output of all three tools carries line numbers.
- `npm run typecheck`, `npm run lint`, `npm test` all pass (4 pre-existing failures in `fs-write.test.ts` are macOS `/var` vs `/private/var` realpath artifacts, unrelated to this change).