### PR TITLE
TEST: Cover WSL-flavored whitespace scenarios (line 1, mixed endings, BOM+CRLF)

### DIFF
--- a/test/integration/first-line-whitespace.test.ts
+++ b/test/integration/first-line-whitespace.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { readFile } from "fs/promises";
 import { withTempFile, setupIntegrationTest, getText, extractHash } from "../support/fixtures";
 
-
 describe("replace tool — first-line whitespace preservation", () => {
   it("preserves leading whitespace on the first line of the replacement (LF file)", async () => {
     await withTempFile("sample.ts", "aaa\nbbb\nccc\n", async ({ cwd, path }) => {
@@ -83,6 +82,70 @@ describe("replace tool — first-line whitespace preservation", () => {
       );
       expect(editResult.content[0].text).toContain("Successfully replaced");
       expect(await readFile(path, "utf-8")).toBe("aaa\n  BBB\nccc\n");
+    });
+  });
+
+  it("preserves whitespace when the replaced range starts at file line 1", async () => {
+    await withTempFile("sample.ts", "  aaa\nbbb\nccc\n", async ({ cwd, path }) => {
+      const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
+      const readResult = await readTool.execute("r1", { path: "sample.ts" }, undefined, undefined, ctx);
+      const lines = getText(readResult).split("\n");
+      const aHash = extractHash(lines.find((l: string) => l.includes("│  aaa"))!);
+      const editResult = await editTool.execute(
+        "e1",
+        { path: "sample.ts", remove_from: aHash, remove_to: aHash, replacement_text: "    AAA" },
+        undefined, undefined, ctx,
+      );
+      expect(editResult.content[0].text).toContain("Successfully replaced");
+      expect(await readFile(path, "utf-8")).toBe("    AAA\nbbb\nccc\n");
+    });
+  });
+
+  it("preserves whitespace in a file with mixed LF/CRLF endings (WSL signature)", async () => {
+    await withTempFile("sample.ts", "aaa\nbbb\r\nccc\r\n", async ({ cwd, path }) => {
+      const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
+      const readResult = await readTool.execute("r1", { path: "sample.ts" }, undefined, undefined, ctx);
+      const lines = getText(readResult).split("\n");
+      const bHash = extractHash(lines.find((l: string) => l.includes("│bbb"))!);
+      const editResult = await editTool.execute(
+        "e1",
+        { path: "sample.ts", remove_from: bHash, remove_to: bHash, replacement_text: "  BBB" },
+        undefined, undefined, ctx,
+      );
+      expect(editResult.content[0].text).toContain("Successfully replaced");
+      expect(await readFile(path, "utf-8")).toBe("aaa\n  BBB\nccc\n");
+    });
+  });
+
+  it("preserves whitespace in a CRLF-first mixed-ending file (WSL signature)", async () => {
+    await withTempFile("sample.ts", "aaa\r\nbbb\nccc\n", async ({ cwd, path }) => {
+      const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
+      const readResult = await readTool.execute("r1", { path: "sample.ts" }, undefined, undefined, ctx);
+      const lines = getText(readResult).split("\n");
+      const bHash = extractHash(lines.find((l: string) => l.includes("│bbb"))!);
+      const editResult = await editTool.execute(
+        "e1",
+        { path: "sample.ts", remove_from: bHash, remove_to: bHash, replacement_text: "  BBB" },
+        undefined, undefined, ctx,
+      );
+      expect(editResult.content[0].text).toContain("Successfully replaced");
+      expect(await readFile(path, "utf-8")).toBe("aaa\r\n  BBB\r\nccc\r\n");
+    });
+  });
+
+  it("preserves whitespace and BOM when replacing the first line of a CRLF file", async () => {
+    await withTempFile("sample.ts", "\uFEFFaaa\r\nbbb\r\n", async ({ cwd, path }) => {
+      const { ctx, readTool, editTool } = setupIntegrationTest(cwd);
+      const readResult = await readTool.execute("r1", { path: "sample.ts" }, undefined, undefined, ctx);
+      const lines = getText(readResult).split("\n");
+      const aHash = extractHash(lines.find((l: string) => l.includes("│aaa"))!);
+      const editResult = await editTool.execute(
+        "e1",
+        { path: "sample.ts", remove_from: aHash, remove_to: aHash, replacement_text: "  AAA" },
+        undefined, undefined, ctx,
+      );
+      expect(editResult.content[0].text).toContain("Successfully replaced");
+      expect(await readFile(path, "utf-8")).toBe("\uFEFF  AAA\r\nbbb\r\n");
     });
   });
 });


### PR DESCRIPTION
Extends the first-line whitespace regression tests with WSL-typical conditions:
- replaced range starting at file line 1
- mixed LF/CRLF endings (both orders)
- UTF-8 BOM + CRLF file

All whitespace assertions pass locally; running the Windows CI matrix to confirm.