### PR TITLE
Accept lone newline-separated strings for replacement_lines and lines

### DIFF
--- a/src/insert.ts
+++ b/src/insert.ts
@@ -51,12 +51,26 @@ const insertDirectionSchema = Type.Union(
   { description: '"after" or "before"' },
 );
 
-const insertLinesSchema = Type.Array(
+const insertLinesArraySchema = Type.Array(
   Type.String({
     description: "One line to insert; never embed \\n inside an element.",
   }),
   {
     description: 'One string per line; [""] is a blank line; never include the anchor line.',
+  }
+);
+
+const insertLinesSchema = Type.Union(
+  [
+    insertLinesArraySchema,
+    Type.String({
+      description:
+        "Same lines as a single newline-separated string; it is split on newlines. Prefer the array form.",
+    }),
+  ],
+  {
+    description:
+      'New lines as an array (preferred) or a single newline-separated string. Example: {"anchor":"Ab12","direction":"after","lines":["first line","second line"]}. [""] is a blank line; never include the anchor line.',
   }
 );
 

--- a/src/payload-contract.ts
+++ b/src/payload-contract.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
-import { isRec, normalizeAnchors, normalizeFilePath, rejectUnknownFields } from "./utils";
+import { isRec, normalizeAnchors, normalizeFilePath, rejectUnknownFields, splitLines } from "./utils";
 
-const replacementLinesSchema = Type.Array(
+const replacementLinesArraySchema = Type.Array(
   Type.String({
     description:
       "One replacement line; never embed \\n inside an element.",
@@ -9,6 +9,20 @@ const replacementLinesSchema = Type.Array(
   {
     description:
       "One string per line. Use [] to delete the range.",
+  },
+);
+
+const replacementLinesSchema = Type.Union(
+  [
+    replacementLinesArraySchema,
+    Type.String({
+      description:
+        "Same lines as a single newline-separated string; it is split on newlines. Prefer the array form.",
+    }),
+  ],
+  {
+    description:
+      'Replacement lines as an array (preferred) or a single newline-separated string. Example: {"remove_from":"Ab12","remove_to":"Cd34","replacement_lines":["first line","second line"]}. Use [] to delete the range.',
   },
 );
 
@@ -21,6 +35,7 @@ const removeToSchema = Type.String({
   description:
     "Bare 4-char anchor from a read row (the text before the `│` separator), never the row content. Marks the LAST line to remove (inclusive)",
 });
+
 const pathRequiredSchema = Type.String({
   description:
     "Path to the file the anchors were served for; required and must match anchor ownership. Anchors still resolve the target.",
@@ -56,6 +71,15 @@ export type ReqParams = {
 };
 
 const ROOT_KS = new Set(["path", "remove_from", "remove_to", "replacement_lines"]);
+
+export function coerceLineFields(record: Record<string, unknown>): void {
+  for (const key of ["replacement_lines", "lines"] as const) {
+    if (typeof record[key] === "string") {
+      record[key] = splitLines(record[key]);
+    }
+  }
+}
+
 export function assertReq(request: unknown): asserts request is ReqParams {
   if (!isRec(request)) {
     throw new Error("[E_BAD_SHAPE] Edit request must be an object.");
@@ -71,7 +95,7 @@ export function assertReq(request: unknown): asserts request is ReqParams {
     request.replacement_lines.some((line) => typeof line !== "string")
   ) {
     throw new Error(
-      '[E_BAD_SHAPE] Edit request requires "remove_from", "remove_to", and "replacement_lines" (array of strings, one per line; use [] to delete).',
+      '[E_BAD_SHAPE] Edit request requires "remove_from", "remove_to", and "replacement_lines" (array of strings, one per line, or a single newline-separated string; use [] to delete).',
     );
   }
 }
@@ -83,6 +107,7 @@ export function normReq(input: unknown): unknown {
   const record: Record<string, unknown> = { ...input };
   normalizeFilePath(record);
   normalizeAnchors(record);
+  coerceLineFields(record);
   return record;
 }
 

--- a/test/core/replace-normalize.test.ts
+++ b/test/core/replace-normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normReq } from "../../src/payload-contract";
+import { assertReq, normReq } from "../../src/payload-contract";
 
 describe("normReq", () => {
 	it("returns non-record input as-is", () => {
@@ -109,5 +109,47 @@ describe("normReq - top-level shape", () => {
 		expect(input.remove_from).toBe(origFrom);
 		expect(input.remove_to).toBe(origTo);
 		expect(input.replacement_lines).toBe(origNc);
+	});
+});
+describe("normReq - lone string line fields", () => {
+	it("splits a replacement_lines string on newlines", () => {
+		const result = normReq({
+			remove_from: "ATIm", remove_to: "BeSR",
+			replacement_lines: "first line\nsecond line",
+		}) as Record<string, unknown>;
+		expect(result.replacement_lines).toEqual(["first line", "second line"]);
+	});
+
+	it("drops a single trailing newline", () => {
+		const result = normReq({
+			remove_from: "ATIm", remove_to: "BeSR",
+			replacement_lines: "first line\nsecond line\n",
+		}) as Record<string, unknown>;
+		expect(result.replacement_lines).toEqual(["first line", "second line"]);
+	});
+
+	it("coerces the insert lines field the same way", () => {
+		const result = normReq({
+			anchor: "ATIm", direction: "after",
+			lines: "one\ntwo",
+		}) as Record<string, unknown>;
+		expect(result.lines).toEqual(["one", "two"]);
+	});
+
+	it("leaves array fields untouched", () => {
+		const input = {
+			remove_from: "ATIm", remove_to: "BeSR",
+			replacement_lines: ["kept"],
+		};
+		const result = normReq(input) as Record<string, unknown>;
+		expect(result.replacement_lines).toEqual(["kept"]);
+	});
+
+	it("assertReq accepts the coerced form", () => {
+		const normalized = normReq({
+			remove_from: "ATIm", remove_to: "BeSR",
+			replacement_lines: "a\nb",
+		});
+		expect(() => assertReq(normalized)).not.toThrow();
 	});
 });


### PR DESCRIPTION
Models frequently emit a plain string where the schema demands `string[]` — e.g. `"replacement_lines": "first line\\nsecond line"` — which then fails shape validation after core JSON parsing succeeds. Observed repeatedly in production sessions (array-intent content arriving as YAML-style scalars, bare words, or single strings), including from frontier models, ending in retry loops and aborted runs.

This change:
- Widens both schemas (`replacement_lines`, insert `lines`) to `string[] | string` with a JSON shape example in the description, so models are licensed to emit the string form.
- Coerces a lone string via the existing `splitLines()` inside `normReq()`, covering replace preview + execute and insert preview + execute + input shaping. Silent by design: both shapes are valid input, not a fixup, so no strict-input warning is recorded.
- Adds 5 regression tests in `test/core/replace-normalize.test.ts`.

Scope note: this rescues valid-JSON string emissions. It cannot rescue calls that die in core JSON parsing (completely unquoted values) — those never reach the extension — but licensing the string form in the schema should convert most of those attempts into valid emissions.

Gates: `tsc --noEmit` clean, eslint clean on touched files, 16/16 normalize tests, 56/56 neighboring insert/replace/edit suites.